### PR TITLE
Add city and category selection landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import Home from "./pages/Home";
 import Index from "./pages/Index";
 import ShopDetail from "./pages/ShopDetail";
 import Login from "./pages/Login";
@@ -19,7 +20,8 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route path="/" element={<Home />} />
+          <Route path="/shops" element={<Index />} />
           <Route path="/shop/:id" element={<ShopDetail />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register-shop" element={<RegisterShop />} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import HeroSection from "@/components/HeroSection";
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+
+const categories = [
+  "Bar & Caffè",
+  "Ristoranti",
+  "Librerie",
+  "Bellezza",
+  "Abbigliamento",
+];
+
+const Home = () => {
+  const [city, setCity] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const goToShops = (category: string | null) => {
+    const params = new URLSearchParams();
+    if (city) params.append("city", city);
+    if (category && category !== "Tutti") params.append("category", category);
+    navigate(`/shops?${params.toString()}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <HeroSection />
+      <div className="container mx-auto px-4 py-12 text-center space-y-6">
+        {!city ? (
+          <>
+            <h2 className="text-2xl font-display font-bold mb-4">
+              Scegli la tua città
+            </h2>
+            <div className="flex flex-wrap justify-center gap-4">
+              {["Torino", "Milano", "Roma"].map((c) => (
+                <Button
+                  key={c}
+                  variant="outline"
+                  onClick={() => setCity(c)}
+                  className="px-6 py-3 text-lg"
+                >
+                  {c}
+                </Button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-2xl font-display font-bold mb-4">
+              Scegli una categoria
+            </h2>
+            <div className="flex flex-wrap justify-center gap-4">
+              <Button
+                variant="outline"
+                className="px-6 py-3 text-lg"
+                onClick={() => goToShops(null)}
+              >
+                Tutti i negozi
+              </Button>
+              {categories.map((cat) => (
+                <Button
+                  key={cat}
+                  variant="outline"
+                  className="px-6 py-3 text-lg"
+                  onClick={() => goToShops(cat)}
+                >
+                  {cat}
+                </Button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useShops } from "@/hooks/useShops";
 import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
@@ -10,14 +11,18 @@ import ShopMap from "@/components/ShopMap";
 import { Link } from "react-router-dom";
 
 const Index = () => {
+  const [searchParams] = useSearchParams();
+  const initialCity = searchParams.get('city');
+  const initialCategory = searchParams.get('category');
+
   const [view, setView] = useState<'grid' | 'map'>('grid');
-  const [filters, setFilters] = useState<FilterState>({
-    categories: [],
-    cities: [],
+  const [filters, setFilters] = useState<FilterState>(() => ({
+    categories: initialCategory ? [initialCategory] : [],
+    cities: initialCity ? [initialCity] : [],
     priceRange: [10, 200],
     minRating: 0,
     maxDistance: 1000
-  });
+  }));
 
   const { shops, isLoading, error } = useShops();
 
@@ -28,8 +33,12 @@ const Index = () => {
         return false;
       }
       
-      // City filter
-      if (filters.cities.length > 0 && !filters.cities.includes(shop.neighborhood)) {
+      // City or neighborhood filter
+      if (
+        filters.cities.length > 0 &&
+        !filters.cities.includes(shop.neighborhood) &&
+        !filters.cities.includes(shop.city)
+      ) {
         return false;
       }
       

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -172,7 +172,7 @@ const Profile = () => {
                         <p className="text-muted-foreground mb-4">
                           Non hai ancora acquistato nessuna gift card
                         </p>
-                        <Link to="/">
+                        <Link to="/shops">
                           <Button>Esplora negozi</Button>
                         </Link>
                       </div>

--- a/src/pages/ShopDetail.tsx
+++ b/src/pages/ShopDetail.tsx
@@ -37,7 +37,7 @@ const ShopDetail = () => {
         <Header />
         <div className="container mx-auto px-4 py-12 text-center">
           <h1 className="text-2xl font-bold mb-4">Negozio non trovato</h1>
-          <Link to="/">
+          <Link to="/shops">
             <Button>Torna alla Home</Button>
           </Link>
         </div>
@@ -51,7 +51,7 @@ const ShopDetail = () => {
       
       {/* Back Button */}
       <div className="container mx-auto px-4 py-4">
-        <Link to="/">
+        <Link to="/shops">
           <Button variant="ghost" className="mb-4">
             <ArrowLeft className="w-4 h-4 mr-2" />
             Torna al catalogo


### PR DESCRIPTION
## Summary
- add `Home` page for selecting city and category
- read query params in `Index` to preapply filters
- update `/` to show `Home` and move shop list to `/shops`
- tweak internal links to point to `/shops`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6881717c1d648324b2e040c41611b09e